### PR TITLE
RedfishPkg/RedfishDebugLib: provide Redfish debug

### DIFF
--- a/OvmfPkg/RiscVVirt/Sec/SecMain.c
+++ b/OvmfPkg/RiscVVirt/Sec/SecMain.c
@@ -55,6 +55,7 @@ SecStartup (
   EFI_STATUS                  Status;
   UINT64                      UefiMemoryBase;
   UINT64                      StackBase;
+  UINT32                      StackSize;
 
   //
   // Report Status Code to indicate entering SEC core
@@ -71,9 +72,9 @@ SecStartup (
   FirmwareContext.FlattenedDeviceTree = (UINT64)DeviceTreeAddress;
   SetFirmwareContextPointer (&FirmwareContext);
 
-  StackBase = (UINT64)FixedPcdGet32 (PcdOvmfSecPeiTempRamBase) +
-              FixedPcdGet32 (PcdOvmfSecPeiTempRamSize);
-  UefiMemoryBase = StackBase - SIZE_32MB;
+  StackBase      = (UINT64)FixedPcdGet32 (PcdOvmfSecPeiTempRamBase);
+  StackSize      = FixedPcdGet32 (PcdOvmfSecPeiTempRamSize);
+  UefiMemoryBase = StackBase + StackSize - SIZE_32MB;
 
   // Declare the PI/UEFI memory region
   HobList = HobConstructor (
@@ -85,6 +86,8 @@ SecStartup (
   PrePeiSetHobList (HobList);
 
   SecInitializePlatform ();
+
+  BuildStackHob (StackBase, StackSize);
 
   //
   // Process all libraries constructor function linked to SecMain.

--- a/RedfishPkg/Include/Library/RedfishDebugLib.h
+++ b/RedfishPkg/Include/Library/RedfishDebugLib.h
@@ -1,0 +1,90 @@
+/** @file
+  This file defines the Redfish debug library interface.
+
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef REDFISH_DEBUG_LIB_H_
+#define REDFISH_DEBUG_LIB_H_
+
+#include <Uefi.h>
+#include <Library/JsonLib.h>
+#include <Library/RedfishLib.h>
+
+#define DEBUG_REDFISH_NETWORK  DEBUG_INFO   ///< Debug error level for Redfish networking function
+
+/**
+
+  This function dump the Json string in given error level.
+
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  JsonValue   Json value to dump.
+
+  @retval     EFI_SUCCESS         Json string is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpJsonValue (
+  IN UINTN             ErrorLevel,
+  IN EDKII_JSON_VALUE  JsonValue
+  );
+
+/**
+
+  This function dump the status code, header and body in given
+  Redfish payload.
+
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  Payload     Redfish payload to dump
+
+  @retval     EFI_SUCCESS         Redfish payload is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpRedfishPayload (
+  IN UINTN            ErrorLevel,
+  IN REDFISH_PAYLOAD  Payload
+  );
+
+/**
+
+  This function dump the status code, header and body in given
+  Redfish response.
+
+  @param[in]  Message     Message string
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  Response    Redfish response to dump
+
+  @retval     EFI_SUCCESS         Redfish response is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpRedfishResponse (
+  IN CONST CHAR8       *Message,
+  IN UINTN             ErrorLevel,
+  IN REDFISH_RESPONSE  *Response
+  );
+
+/**
+
+  This function dump the HTTP status code.
+
+  @param[in]  ErrorLevel     DEBUG macro error level
+  @param[in]  HttpStatusCode HTTP status code
+
+  @retval     EFI_SUCCESS    HTTP status code is printed
+
+**/
+EFI_STATUS
+DumpHttpStatusCode (
+  IN UINTN                 ErrorLevel,
+  IN EFI_HTTP_STATUS_CODE  HttpStatusCode
+  );
+
+#endif

--- a/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.c
+++ b/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.c
@@ -1,0 +1,229 @@
+/** @file
+  Redfish debug library to debug Redfish application.
+
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/RedfishDebugLib.h>
+#include <Library/UefiLib.h>
+
+#ifndef IS_EMPTY_STRING
+#define IS_EMPTY_STRING(a)  ((a) == NULL || (a)[0] == '\0')
+#endif
+
+#define REDFISH_JSON_STRING_LENGTH  200
+#define REDFISH_JSON_OUTPUT_FORMAT  (EDKII_JSON_COMPACT | EDKII_JSON_INDENT(2))
+
+/**
+
+  This function dump the Json string in given error level.
+
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  JsonValue   Json value to dump.
+
+  @retval     EFI_SUCCESS         Json string is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpJsonValue (
+  IN UINTN             ErrorLevel,
+  IN EDKII_JSON_VALUE  JsonValue
+  )
+{
+  CHAR8  *String;
+  CHAR8  *Runner;
+  CHAR8  Buffer[REDFISH_JSON_STRING_LENGTH + 1];
+  UINTN  StrLen;
+  UINTN  Count;
+  UINTN  Index;
+
+  if (JsonValue == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  String = JsonDumpString (JsonValue, REDFISH_JSON_OUTPUT_FORMAT);
+  if (String == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  StrLen = AsciiStrLen (String);
+  if (StrLen == 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Count  = StrLen / REDFISH_JSON_STRING_LENGTH;
+  Runner = String;
+  for (Index = 0; Index < Count; Index++) {
+    AsciiStrnCpyS (Buffer, (REDFISH_JSON_STRING_LENGTH + 1), Runner, REDFISH_JSON_STRING_LENGTH);
+    Buffer[REDFISH_JSON_STRING_LENGTH] = '\0';
+    DEBUG ((ErrorLevel, "%a", Buffer));
+    Runner += REDFISH_JSON_STRING_LENGTH;
+  }
+
+  Count = StrLen % REDFISH_JSON_STRING_LENGTH;
+  if (Count > 0) {
+    DEBUG ((ErrorLevel, "%a", Runner));
+  }
+
+  DEBUG ((ErrorLevel, "\n"));
+
+  FreePool (String);
+  return EFI_SUCCESS;
+}
+
+/**
+
+  This function dump the status code, header and body in given
+  Redfish payload.
+
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  Payload     Redfish payload to dump
+
+  @retval     EFI_SUCCESS         Redfish payload is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpRedfishPayload (
+  IN UINTN            ErrorLevel,
+  IN REDFISH_PAYLOAD  Payload
+  )
+{
+  EDKII_JSON_VALUE  JsonValue;
+
+  if (Payload == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  JsonValue = RedfishJsonInPayload (Payload);
+  if (JsonValue != NULL) {
+    DEBUG ((ErrorLevel, "Payload:\n"));
+    DumpJsonValue (ErrorLevel, JsonValue);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+
+  This function dump the HTTP status code.
+
+  @param[in]  ErrorLevel     DEBUG macro error level
+  @param[in]  HttpStatusCode HTTP status code
+
+  @retval     EFI_SUCCESS    HTTP status code is printed
+
+**/
+EFI_STATUS
+DumpHttpStatusCode (
+  IN UINTN                 ErrorLevel,
+  IN EFI_HTTP_STATUS_CODE  HttpStatusCode
+  )
+{
+  switch (HttpStatusCode) {
+    case HTTP_STATUS_100_CONTINUE:
+      DEBUG ((ErrorLevel, "Status code: 100 CONTINUE\n"));
+      break;
+    case HTTP_STATUS_200_OK:
+      DEBUG ((ErrorLevel, "Status code: 200 OK\n"));
+      break;
+    case HTTP_STATUS_201_CREATED:
+      DEBUG ((ErrorLevel, "Status code: 201 CREATED\n"));
+      break;
+    case HTTP_STATUS_202_ACCEPTED:
+      DEBUG ((ErrorLevel, "Status code: 202 ACCEPTED\n"));
+      break;
+    case HTTP_STATUS_304_NOT_MODIFIED:
+      DEBUG ((ErrorLevel, "Status code: 304 NOT MODIFIED\n"));
+      break;
+    case HTTP_STATUS_400_BAD_REQUEST:
+      DEBUG ((ErrorLevel, "Status code: 400 BAD REQUEST\n"));
+      break;
+    case HTTP_STATUS_401_UNAUTHORIZED:
+      DEBUG ((ErrorLevel, "Status code: 401 UNAUTHORIZED\n"));
+      break;
+    case HTTP_STATUS_403_FORBIDDEN:
+      DEBUG ((ErrorLevel, "Status code: 403 FORBIDDEN\n"));
+      break;
+    case HTTP_STATUS_404_NOT_FOUND:
+      DEBUG ((ErrorLevel, "Status code: 404 NOT FOUND\n"));
+      break;
+    case HTTP_STATUS_405_METHOD_NOT_ALLOWED:
+      DEBUG ((ErrorLevel, "Status code: 405 METHOD NOT ALLOWED\n"));
+      break;
+    case HTTP_STATUS_500_INTERNAL_SERVER_ERROR:
+      DEBUG ((ErrorLevel, "Status code: 500 INTERNAL SERVER ERROR\n"));
+      break;
+    default:
+      DEBUG ((ErrorLevel, "Status code: 0x%x\n", HttpStatusCode));
+      break;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+
+  This function dump the status code, header and body in given
+  Redfish response.
+
+  @param[in]  Message     Message string
+  @param[in]  ErrorLevel  DEBUG macro error level
+  @param[in]  Response    Redfish response to dump
+
+  @retval     EFI_SUCCESS         Redfish response is printed.
+  @retval     Others              Errors occur.
+
+**/
+EFI_STATUS
+DumpRedfishResponse (
+  IN CONST CHAR8       *Message,
+  IN UINTN             ErrorLevel,
+  IN REDFISH_RESPONSE  *Response
+  )
+{
+  UINTN  Index;
+
+  if (Response == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IS_EMPTY_STRING (Message)) {
+    DEBUG ((ErrorLevel, "%a\n", Message));
+  }
+
+  //
+  // status code
+  //
+  if (Response->StatusCode != NULL) {
+    DumpHttpStatusCode (ErrorLevel, *(Response->StatusCode));
+  }
+
+  //
+  // header
+  //
+  if (Response->HeaderCount > 0) {
+    DEBUG ((ErrorLevel, "Header: %d\n", Response->HeaderCount));
+    for (Index = 0; Index < Response->HeaderCount; Index++) {
+      DEBUG ((ErrorLevel, "  %a: %a\n", Response->Headers[Index].FieldName, Response->Headers[Index].FieldValue));
+    }
+  }
+
+  //
+  // Body
+  //
+  if (Response->Payload != NULL) {
+    DumpRedfishPayload (ErrorLevel, Response->Payload);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.inf
+++ b/RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.inf
@@ -1,0 +1,39 @@
+## @file
+#  INF file for Redfish debug library.
+#
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = RedfishDebugLib
+  FILE_GUID                      = 7F64C79F-ABD0-4446-86B5-2C1AE36168AD
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RedfishDebugLib| DXE_DRIVER UEFI_DRIVER
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  RedfishDebugLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  RedfishPkg/RedfishPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  JsonLib
+  MemoryAllocationLib
+  RedfishLib
+  UefiLib
+
+[Depex]
+  TRUE

--- a/RedfishPkg/RedfishLibs.dsc.inc
+++ b/RedfishPkg/RedfishLibs.dsc.inc
@@ -6,6 +6,7 @@
 # of EDKII network library classes.
 #
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -17,5 +18,6 @@
   RedfishCrtLib|RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
   JsonLib|RedfishPkg/Library/JsonLib/JsonLib.inf
   RedfishLib|RedfishPkg/PrivateLibrary/RedfishLib/RedfishLib.inf
+  RedfishDebugLib|RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.inf
 !endif
 

--- a/RedfishPkg/RedfishPkg.dec
+++ b/RedfishPkg/RedfishPkg.dec
@@ -4,6 +4,7 @@
 # Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2023, American Megatrends International LLC.
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -54,6 +55,10 @@
   #   Redfish packet.
   #
   RedfishContentCodingLib|Include/Library/RedfishContentCodingLib.h
+
+  ##  @libraryclass Redfish Debug Library
+  #   Library provides Redfish debug functions.
+  RedfishDebugLib|Include/Library/RedfishDebugLib.h
 
 [LibraryClasses.Common.Private]
   ##  @libraryclass  Provides the private C runtime library functions.

--- a/RedfishPkg/RedfishPkg.dsc
+++ b/RedfishPkg/RedfishPkg.dsc
@@ -58,5 +58,6 @@
   RedfishPkg/PrivateLibrary/RedfishCrtLib/RedfishCrtLib.inf
   RedfishPkg/Library/JsonLib/JsonLib.inf
   RedfishPkg/PrivateLibrary/RedfishLib/RedfishLib.inf
+  RedfishPkg/Library/RedfishDebugLib/RedfishDebugLib.inf
 
   !include RedfishPkg/Redfish.dsc.inc

--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExDxe.inf
@@ -4,6 +4,7 @@
 #  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
 #  Copyright (c) 2023, American Megatrends International LLC.
+#  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -44,6 +45,7 @@
   PrintLib
   MemoryAllocationLib
   NetLib
+  RedfishDebugLib
   UefiLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint

--- a/RedfishPkg/RedfishRestExDxe/RedfishRestExInternal.h
+++ b/RedfishPkg/RedfishRestExDxe/RedfishRestExInternal.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2019-2020 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -21,6 +22,7 @@
 #include <Library/HttpIoLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/NetLib.h>
+#include <Library/RedfishDebugLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiDriverEntryPoint.h>

--- a/ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.uni
+++ b/ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.uni
@@ -52,7 +52,7 @@
 #string STR_PING_NOROUTE_FOUND       #language en-US "There is no route to the destination '%B%s%N' from the source '%B%s%N' was found.\r\n"
 #string STR_PING_START               #language en-US "Ping %s %d data bytes.\r\n"
 #string STR_PING_TIMEOUT             #language en-US "Echo request sequence %d timeout.\r\n"
-#string STR_PING_REPLY_INFO          #language en-US "%d bytes from %s : icmp_seq=%d ttl=%d time%d~%dms\r\n"
+#string STR_PING_REPLY_INFO          #language en-US "%d bytes from %s : icmp_seq=%d ttl=%d time=%d~%dms\r\n"
 #string STR_PING_STAT                #language en-US "\n%d packets transmitted, %d received, %d%% packet loss, time %dms\r\n"
 #string STR_PING_RTT                 #language en-US "\nRtt(round trip time) min=%d~%dms max=%d~%dms avg=%d~%dms\r\n"
 

--- a/ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.uni
+++ b/ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.uni
@@ -33,7 +33,7 @@
 #string STR_PING6_NOSOURCE_INDOMAIN        #language en-US  "No sources in %s's multicast domain.\r\n"
 #string STR_PING6_START                    #language en-US  "Ping %s %d data bytes\r\n"
 #string STR_PING6_TIMEOUT                  #language en-US  "Echo request sequence %d timeout.\r\n"
-#string STR_PING6_REPLY_INFO               #language en-US  "%d bytes from %s : icmp_seq=%d ttl=%d time%d~%dms\r\n"
+#string STR_PING6_REPLY_INFO               #language en-US  "%d bytes from %s : icmp_seq=%d ttl=%d time=%d~%dms\r\n"
 #string STR_PING6_STAT                     #language en-US  "\n%d packets transmitted, %d received, %d%% packet loss, time %dms\r\n"
 #string STR_PING6_RTT                      #language en-US  "\nRtt(round trip time) min=%d~%dms max=%d~%dms avg=%d~%dms\r\n"
 


### PR DESCRIPTION
Introduce RedfishDebugLib to RedfishPkg. This library provides several debugging functions for Redfish application. Redfish drivers rely on Rest Ex protocol to communicate with BMC and the communication data may be big and complicated. Use RedfishDebugLib in RedfishRestExDxe to simplify debugging process.


Cc: Abner Chang <abner.chang@amd.com>
Cc: Igor Kulchytskyy <igork@ami.com>
Cc: Nick Ramirez <nramirez@nvidia.com>
Reviewed-by: Abner Chang <abner.chang@amd.com>